### PR TITLE
Ignore GraphQL introspection queries by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,12 @@ Dockerize ``INTERNAL_IPS``
     hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
     INTERNAL_IPS += [ip[:-1] + '1' for ip in ips]
 
+Configuration
+-------------
+
+By default, introspection queries will be ignored and no debug information will be added. If you'd like to include them as well, set 
+``GRAPHIQL_DEBUG_TOOLBAR_INTROSPECTIONS=True`` in settings.
+
 
 Limitations
 -----------

--- a/graphiql_debug_toolbar/middleware.py
+++ b/graphiql_debug_toolbar/middleware.py
@@ -1,6 +1,7 @@
 import json
 from collections import OrderedDict
 
+from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils.encoding import force_text
 
@@ -23,6 +24,11 @@ def set_content_length(response):
 def get_payload(request, response, toolbar):
     content = force_text(response.content, encoding=response.charset)
     payload = json.loads(content, object_pairs_hook=OrderedDict)
+
+    if not getattr(settings, 'GRAPHIQL_DEBUG_TOOLBAR_INTROSPECTIONS', False):
+        if payload.get('data', None) is not None and all(_.startswith('__') for _ in payload.get('data', {}).keys()):
+            return payload
+
     payload['debugToolbar'] = OrderedDict([('panels', OrderedDict())])
 
     for panel in reversed(toolbar.enabled_panels):


### PR DESCRIPTION
Tools like GraphQL playground run introspections constantly. This means that the information you really care about (manually run queries) gets replaced by the introspection query debug info every time that happens. This update ignores introspection query results by default and adds an option track them as well.