### PR TITLE
Only Enable Toolbar for GraphiQL enabled views

### DIFF
--- a/graphiql_debug_toolbar/middleware.py
+++ b/graphiql_debug_toolbar/middleware.py
@@ -51,7 +51,7 @@ class DebugToolbarMiddleware(BaseMiddleware):
 
     def process_view(self, request, view_func, *args):
         if hasattr(view_func, 'view_class') and\
-                issubclass(view_func.view_class, GraphQLView):
+                issubclass(view_func.view_class, GraphQLView) and view_func.view_class.graphiql:
             request._graphql_view = True
 
     def __call__(self, request):


### PR DESCRIPTION
In a client project we are making use of GraphQL batching which bundles several graphql queries into one request. This results in the top level JSON body data structure being a list. This causes an exception when using that URL with this middleware enabled.

This change checks that GraphiQL is enabled before adding in the debugToolbar content.

Please let me know if you would like any more changes or tests added.